### PR TITLE
add CSP

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,30 @@
 import { fileURLToPath } from 'url';
 import createMDX from '@next/mdx';
 
+// 'unsafe-inline' is required for Next.js hydration scripts and the GTM init
+// inline script (Analytics.tsx). To remove it, adopt nonce-based CSP via
+// Next.js middleware.
+// 'unsafe-eval' is added in dev only for Turbopack HMR.
+const isDev = process.env.NODE_ENV === 'development';
+const contentSecurityPolicyHeaderValue = [
+  "default-src 'self'",
+  `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ''} https://www.googletagmanager.com https://www.google-analytics.com`,
+  // Path-scoped: GA4 pings /g/collect on www.google.com for cross-domain
+  // measurement. If a future GA update redirects this path, the redirect
+  // target will need its own allowlist entry (CSP paths don't follow 30x).
+  "connect-src 'self' https://api.opensanctions.org https://www.google-analytics.com https://region1.google-analytics.com https://www.google.com/g/collect",
+  "img-src 'self' data: https://assets.opensanctions.org https://www.google-analytics.com https://www.googletagmanager.com",
+  "style-src 'self' 'unsafe-inline'",
+  "font-src 'self' data:",
+  // EP embeds no iframes. Without this, frame-src falls back to default-src 'self',
+  // which would still permit same-origin frames. If we ever add an embed (YouTube,
+  // a map, etc.), allowlist its origin here. Or change to 'self' to allow same-origin.
+  "frame-src 'none'",
+  "object-src 'none'",
+  "base-uri 'self'",
+  "form-action 'self'",
+].join('; ');
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
@@ -20,11 +44,27 @@ const nextConfig = {
         protocol: 'https',
         hostname: 'assets.opensanctions.org',
       },
+      // TODO: remove directus for images? alternatively, add to CSP
       {
         protocol: 'https',
         hostname: 'opensanctions.directus.app',
       },
     ],
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        // Switch to Content-Security-Policy once validated in staging.
+        // report-only — browsers log violations to the console but nothing is blocked.
+        headers: [
+          {
+            key: 'Content-Security-Policy-Report-Only',
+            value: contentSecurityPolicyHeaderValue,
+          },
+        ],
+      },
+    ];
   },
 };
 


### PR DESCRIPTION
ref https://github.com/opensanctions/operations/issues/2331

this CSP is based on the one at https://github.com/opensanctions/knowledgebase/blob/main/site/next.config.js#L26-L37
It doesn't have stripe, external forms, or directus — we don't actually seem to be using the latter for assets/images. 
It adds `google.com/g/collect` instead of `doubleclick` — I didn't look into the detail of how we do google tracking, but `collect` came up as a violation when I locally accepted tracking, and there was no complaint about `doubleclick` being missing. It's report-only, so should be safe to merge and test in the wild to check if anything is missing. 

Checked the following locally without issue, as suggested by Claude:

### Must-check (broadest CSP coverage)

- **`/`** — homepage. Hits `assets.opensanctions.org` logo (img-src), and `WorldMap` fetches `/data/countries-110m.json` (connect-src self) plus uses inline `style={{...}}` on tooltips (style-src unsafe-inline). `components/WorldMap.tsx:60`
- **`/persons/<entityId>/`** — pick any person. Injects an inline `<Script type="application/ld+json">` (script-src unsafe-inline). `app/persons/[entityId]/page.tsx:78`
- **`/positions/<entityId>/`** — same inline JSON-LD plus the `WorldMap` rendered inside the `Hero` with a flag from `assets.opensanctions.org/images/flags/...` (img-src). `app/positions/[entityId]/page.tsx:119`, `components/WorldMap.tsx:212`
- **`/territories/<slug>/`** and **`/territories/<slug>/<section>/`** — heavy content pages with the most external links and entity rendering.

### Analytics path — accept the banner first to trigger it

Any page after clicking **"OK"** on the analytics consent banner. This is what actually exercises:

- script-src → `googletagmanager.com`, `google-analytics.com`
- connect-src → `google-analytics.com`, `region1.google-analytics.com`, `stats.g.doubleclick.net`
- img-src → tracking pixels on `google-analytics.com`, `googletagmanager.com`

Without consent, GA never loads and you won't see CSP coverage for those. `components/Analytics.tsx:18`

### Lower priority but worth a glance

- **`/regions/`** and **`/regions/<region>/`** — RegionsNav + map usage.
- **`/about/contribute/wikidata/`** and **`/about/contribute/poliloom/`** — only MDX pages with `<Figure>` embedded images. Sources are all `/images/docs/...` (self), so should be clean. `app/about/contribute/wikidata/page.mdx:90`
- **`/sources/`** — `DataSourcesSection` rendering with external dataset links (anchor links, so not CSP-constrained, but a good full-coverage sweep).
