### PR TITLE
add safeJsonLd for escaping `<`, `>`, and `&`

### DIFF
--- a/app/persons/[entityId]/page.tsx
+++ b/app/persons/[entityId]/page.tsx
@@ -9,7 +9,7 @@ import OccupanciesTable from '@/components/OccupanciesTable';
 import PersonProfile from '@/components/PersonProfile';
 import Container from 'react-bootstrap/Container';
 import { getAdjacent, getEntityDatasets } from '@/lib/data';
-import { getSchemaEntityPage } from '@/lib/schema';
+import { getSchemaEntityPage, safeJsonLd } from '@/lib/schema';
 import { getFirst, getEntityProperty } from '@/lib/types';
 
 export const maxDuration = 25;
@@ -78,7 +78,7 @@ export default async function PersonPage({ params }: PersonPageProps) {
         <Script
           type="application/ld+json"
           id="json-ld"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }}
+          dangerouslySetInnerHTML={{ __html: safeJsonLd(structured) }}
         />
       )}
       <Hero title={person.caption} size="small" />

--- a/app/positions/[entityId]/page.tsx
+++ b/app/positions/[entityId]/page.tsx
@@ -16,7 +16,7 @@ import {
   getTerritorySummaries,
   getTerritories,
 } from '@/lib/data';
-import { getSchemaEntityPage } from '@/lib/schema';
+import { getSchemaEntityPage, safeJsonLd } from '@/lib/schema';
 import { EntityData, getFirst, getEntityProperty } from '@/lib/types';
 
 export const maxDuration = 25;
@@ -119,7 +119,7 @@ export default async function PositionPage({ params }: PositionPageProps) {
         <Script
           type="application/ld+json"
           id="json-ld"
-          dangerouslySetInnerHTML={{ __html: JSON.stringify(structured) }}
+          dangerouslySetInnerHTML={{ __html: safeJsonLd(structured) }}
         />
       )}
       {territory ? (

--- a/lib/schema.test.ts
+++ b/lib/schema.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+
+import { safeJsonLd } from './schema';
+
+describe('safeJsonLd', () => {
+  it('escapes </script> so a caption cannot break out of a JSON-LD block', () => {
+    const out = safeJsonLd({
+      name: '</script><script>alert(1)</script>',
+    });
+
+    expect(out).not.toContain('</script>');
+    expect(out).not.toContain('<script>');
+    expect(out).toContain('\\u003c/script\\u003e');
+  });
+
+  it('round-trips through JSON.parse', () => {
+    const payload = { name: 'Foo </script> & <b>bar</b>' };
+    expect(JSON.parse(safeJsonLd(payload))).toEqual(payload);
+  });
+});

--- a/lib/schema.ts
+++ b/lib/schema.ts
@@ -17,6 +17,14 @@ function getEveryPoliticianOrganization() {
   };
 }
 
+// Escapes `<`, `>`, `&` so attacker-controlled strings (e.g. entity.caption) cannot break out of a JSON-LD <script> block and execute as HTML.
+export function safeJsonLd(data: unknown): string {
+  return JSON.stringify(data, null, 2).replace(
+    /[<>&]/g,
+    (c) => ({ '<': '\\u003c', '>': '\\u003e', '&': '\\u0026' })[c]!,
+  );
+}
+
 export function getSchemaEntityPage(entity: EntityData) {
   return {
     '@context': 'https://schema.org/',


### PR DESCRIPTION
closes https://github.com/opensanctions/operations/issues/2334